### PR TITLE
Fix "window is not defined" build error

### DIFF
--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -6,7 +6,7 @@ import { AppLayout } from '@/components/layout/AppLayout';
 import { Suspense } from 'react';
 import { PageLoader } from '@/components/layout/PageLoader';
 import { OrganizationProvider } from '@/contexts/OrganizationContext';
-import { AsgardeoProviderWrapper } from "@/components/auth/AsgardeoProviderWrapper";
+import { AsgardeoProviderWithNoSSR } from "@/components/auth/AsgardeoProviderWithNoSSR";
 
 export const metadata: Metadata = {
   title: 'Monyfi SaaS',
@@ -28,13 +28,13 @@ export default function RootLayout({
       </head>
       <body className="font-body antialiased">
         <Suspense fallback={<PageLoader />}>
-          <AsgardeoProviderWrapper>
+          <AsgardeoProviderWithNoSSR>
             <OrganizationProvider>
                 <AppLayout>
                   {children}
                 </AppLayout>
             </OrganizationProvider>
-          </AsgardeoProviderWrapper>
+          </AsgardeoProviderWithNoSSR>
         </Suspense>
         <Toaster />
       </body>

--- a/src/components/auth/AsgardeoProviderWithNoSSR.tsx
+++ b/src/components/auth/AsgardeoProviderWithNoSSR.tsx
@@ -1,0 +1,13 @@
+'use client';
+
+import dynamic from 'next/dynamic';
+import { ReactNode } from 'react';
+
+const AsgardeoProviderWrapper = dynamic(
+  () => import('@/components/auth/AsgardeoProviderWrapper').then(mod => mod.AsgardeoProviderWrapper),
+  { ssr: false }
+);
+
+export function AsgardeoProviderWithNoSSR({ children }: { children: ReactNode }) {
+  return <AsgardeoProviderWrapper>{children}</AsgardeoProviderWrapper>;
+}

--- a/src/components/layout/AppLayout.tsx
+++ b/src/components/layout/AppLayout.tsx
@@ -4,7 +4,11 @@
 import React, { useState, useEffect } from 'react';
 import { usePathname, useRouter } from 'next/navigation';
 import { SidebarProvider, Sidebar, SidebarInset, SidebarRail } from '@/components/ui/sidebar';
-import { AppSidebar } from '@/components/layout/AppSidebar';
+import dynamic from 'next/dynamic';
+
+const AppSidebar = dynamic(() => import('@/components/layout/AppSidebar').then(mod => mod.AppSidebar), {
+  ssr: false,
+});
 import { AppHeader } from './AppHeader';
 import { PageLoader } from './PageLoader';
 import { useOrganization } from '@/contexts/OrganizationContext';

--- a/src/hooks/use-mobile.tsx
+++ b/src/hooks/use-mobile.tsx
@@ -1,27 +1,26 @@
-
 "use client"
 
-import * as React from "react"
+import { useSyncExternalStore } from "react"
 
 const MOBILE_BREAKPOINT = 768
 
+function subscribe(callback: () => void) {
+  window.addEventListener("resize", callback)
+  return () => {
+    window.removeEventListener("resize", callback)
+  }
+}
+
+function getSnapshot() {
+  return window.innerWidth < MOBILE_BREAKPOINT
+}
+
+function getServerSnapshot() {
+  return false // A sensible default for the server
+}
+
 export function useIsMobile() {
-  const [isMobile, setIsMobile] = React.useState(false)
-
-  React.useEffect(() => {
-    const checkIsMobile = () => {
-      setIsMobile(window.innerWidth < MOBILE_BREAKPOINT)
-    }
-
-    // Initial check
-    checkIsMobile()
-
-    // Listen for window resize
-    window.addEventListener("resize", checkIsMobile)
-
-    // Cleanup
-    return () => window.removeEventListener("resize", checkIsMobile)
-  }, [])
-
-  return isMobile
+  // The useSyncExternalStore hook is the recommended way to subscribe to external stores,
+  // and it's perfect for handling browser APIs in a way that is compatible with SSR.
+  return useSyncExternalStore(subscribe, getSnapshot, getServerSnapshot)
 }


### PR DESCRIPTION
The application was failing to build due to a `ReferenceError: window is not defined` error. This was caused by the `@asgardeo/react` library, which is not fully compatible with Next.js Server-Side Rendering (SSR).

The `AsgardeoProvider` was attempting to access browser-only APIs on the server during the build process, causing the build to crash.

This commit resolves the issue by preventing the `AsgardeoProvider` from being rendered on the server. A new client component, `AsgardeoProviderWithNoSSR`, is introduced to dynamically import the `AsgardeoProviderWrapper` with the `ssr: false` option. This ensures that the provider and its children are only rendered on the client side, avoiding the server-side error.