### PR TITLE
feat: Adjust authentication flow for external website

### DIFF
--- a/src/app/callback/route.ts
+++ b/src/app/callback/route.ts
@@ -6,5 +6,5 @@ import { logtoConfig } from '@/lib/logto';
 export async function GET(request: NextRequest) {
   const searchParams = request.nextUrl.searchParams;
   await handleSignIn(logtoConfig, searchParams);
-  redirect('/');
+  redirect('/organizations');
 }

--- a/src/app/login/page.tsx
+++ b/src/app/login/page.tsx
@@ -1,0 +1,7 @@
+import { handleSignIn } from '@/app/actions';
+import { redirect } from 'next/navigation';
+
+export default async function LoginPage() {
+  await handleSignIn();
+  redirect('/'); // This redirect might not be reached, as handleSignIn should redirect to Logto.
+}


### PR DESCRIPTION
This commit adjusts the authentication flow to better support an external marketing website.

The changes include:
- Updated the post-sign-in redirect to point to the `/organizations` page.
- Created a dedicated `/login` page to initiate the sign-in flow from an external site.